### PR TITLE
Moved env vars from env.sh to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,12 @@ ADD ./scripts/ /home/root/scripts
 RUN chmod +x /home/root/scripts/*
 ADD ./empty.pem /home/root/my.pem
 
+ENV GA_EMAIL=thesupersecretemailcode@developer.gserviceaccount.com
+ENV GA_METRICS=ga:pageviews,ga:sessions,ga:avgTimeOnSite
+ENV GA_VIEW_ID=YOUR_VIEW_ID
+ENV GRAPHITE_HOST=YOUR_GRAPHITE_HOST
+ENV GRAPHITE_PORT=2003
+
 ENTRYPOINT ["/home/root/scripts/start.sh"]
 
 RUN apt-get update \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,11 +28,21 @@ ADD ./scripts/ /home/root/scripts
 RUN chmod +x /home/root/scripts/*
 ADD ./empty.pem /home/root/my.pem
 
+# Get the email address from Google Analytics
 ENV GA_EMAIL=thesupersecretemailcode@developer.gserviceaccount.com
+# Choose which metrics to send. You can probably use		
+# this list https://developers.google.com/analytics/devguides/reporting/core/dimsmets
 ENV GA_METRICS=ga:pageviews,ga:sessions,ga:avgTimeOnSite
+# The view id on your Google Analytics account
 ENV GA_VIEW_ID=YOUR_VIEW_ID
+# The hostname of your Graphite instance
 ENV GRAPHITE_HOST=YOUR_GRAPHITE_HOST
+# Graphite port
 ENV GRAPHITE_PORT=2003
+# Want to export data based per minute?
+ENV GA_MINUTES=false
+# Maximum number of results from GA
+ENV GA_MAX_RESULTS=1000
 
 ENTRYPOINT ["/home/root/scripts/start.sh"]
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,6 +16,12 @@ docker run --rm -v /path/to/my.pem:/home/root/my.pem -v /path/to/env.sh:/home/ro
 ## Configuration
 You can either feed the script with params or add your values to the env.sh file. Easiest using Docker is just to configure env.sh.
 
+GA_EMAIL, GA_METRICS, GA_VIEW_ID, GRAPHITE_HOST and GRAPHITE_PORT are all environment variables that can be passed in via the docker run command.
+
+```
+docker run --rm -v /path/to/my.pem:/home/root/my.pem -v /path/to/env.sh:/home/root/scripts/env.sh -e GA_EMAIL=someone@gmail.com -e GA_METRICS=GA_METRICS=ga:pageviews,ga:sessions,ga:avgTimeOnSite,ga:domContentLoadedTime -e GA_VIEW_ID=yourviewid -e GRAPHITE_HOST=graphite -e GRAPHITE_PORT=2003 sitespeedio/gatographite gatographite
+```
+
 ### Choosing which data to fetch
 Metrics that you can fetch is the one in the Google Analytics API:
 [https://developers.google.com/analytics/devguides/reporting/core/dimsmets](https://developers.google.com/analytics/devguides/reporting/core/dimsmets)

--- a/docker/scripts/env.sh
+++ b/docker/scripts/env.sh
@@ -2,22 +2,11 @@
 # setup your GA account
 # http://www.bentedder.com/server-to-server-authorization-for-google-analytics-api-with-node-js/
 
-# Get the email address from Google Analytics
-export GA_EMAIL=thesupersecretemailcode@developer.gserviceaccount.com
 # And the full path to the PEM file
 export GA_PEM_PATH=/home/root/my.pem
-# Choose which metrics to send. You can probably use
-# this list https://developers.google.com/analytics/devguides/reporting/core/dimsmets
-export GA_METRICS=ga:pageviews,ga:sessions,ga:avgTimeOnSite
-# The view id on your Google Analytics account
-export GA_VIEW_ID=YOUR_VIEW_ID
 # Want to export data based per minute?
-export GA_MINUTES=false
+export GA_MINUTES=true
 # Maximum number of results from GA
 export GA_MAX_RESULTS=1000
-# The hostname of your Graphite instance
-export GRAPHITE_HOST=
-# Graphite port
-export GRAPHITE_PORT=2003
 # The start of the key namespace sent to Graphite
 export GRAPHITE_NAMESPACE=google.analytics

--- a/docker/scripts/env.sh
+++ b/docker/scripts/env.sh
@@ -4,9 +4,5 @@
 
 # And the full path to the PEM file
 export GA_PEM_PATH=/home/root/my.pem
-# Want to export data based per minute?
-export GA_MINUTES=true
-# Maximum number of results from GA
-export GA_MAX_RESULTS=1000
 # The start of the key namespace sent to Graphite
 export GRAPHITE_NAMESPACE=google.analytics


### PR DESCRIPTION
I've moved some of the environment variables (most common ones to change) to the Dockerfile rather than the env.sh file to make it easier to change the values.  I've also updated the README to reflect the change but what I've written might need tweaking!